### PR TITLE
Fixes overriding the Name property of an item

### DIFF
--- a/pymsbuild/_generate.py
+++ b/pymsbuild/_generate.py
@@ -171,8 +171,8 @@ def _write_members(f, source_dir, members):
                 else:
                     f.add_item(p._ITEMNAME, p.source, **{
                         "SourceDir": source_dir,
-                        **p.options,
                         "Name": n,
+                        **p.options,
                     })
             elif isinstance(p, Property):
                 g.switch_to("PropertyGroup")


### PR DESCRIPTION
This allows using the `Name=` named argument/option on a single file to completely override the generated name. This was possible with wildcard items already.