### PR TITLE
Allow overriding just the ABI with PYMSBUILD_ABI.

### DIFF
--- a/README.md
+++ b/README.md
@@ -739,7 +739,7 @@ a missing platform.
 Any `*` elements in the wheel tag are filled in from other locations.
 For example, specifying `*-none-any` will infer the interpreter field
 from the current runtime, whil `py3-none-*` will infer the platform
-from the currnet system (or a specific ABI tag).
+from the current system (or a specific ABI tag).
 
 The platform is used to determine the MSBuild target platform. It
 cannot yet automatically select the correct Python libraries, and so
@@ -765,6 +765,9 @@ $env:PYMSBUILD_WHEEL_TAG = "py38-cp38-win_arm64"
 # Directly set the ABI tag (or else taken from wheel tag)
 # This is used for extension module filenames
 $env:PYMSBUILD_ABI_TAG = "cp38-win_arm64"
+
+# Specify the Python ABI (or else taken from ABI tag)
+# This is used for MSBuild options
 
 # Specify the Python platform (or else taken from ABI tag)
 # This is used for MSBuild options

--- a/pymsbuild/_build.py
+++ b/pymsbuild/_build.py
@@ -99,6 +99,7 @@ class BuildState:
         self.targets = Path(__file__).absolute().parent / "targets"
         self.wheel_tag = None
         self.abi_tag = None
+        self.abi_only = None
         self.ext_suffix = None
         self.platform = None
         self.build_number = None
@@ -173,6 +174,7 @@ class BuildState:
 
         self._set_best("ext_suffix", "ExtSuffix", "PYMSBUILD_EXT_SUFFIX", None, getenv)
         self._set_best("abi_tag", "AbiTag", "PYMSBUILD_ABI_TAG", None, getenv)
+        self._set_best("abi_only", "Abi", "PYMSBUILD_ABI", None, getenv)
         self._set_best("wheel_tag", "WheelTag", "PYMSBUILD_WHEEL_TAG", None, getenv)
         self._set_best("platform", None, "PYMSBUILD_PLATFORM", None, getenv)
         self._set_best("configuration", None, "PYMSBUILD_CONFIGURATION", "Release", getenv)
@@ -188,11 +190,13 @@ class BuildState:
         tags = _tags.choose_best_tags(
             ext_suffix = self.ext_suffix,
             abi_tag = self.abi_tag,
+            abi_only = self.abi_only,
             wheel_tag = self.wheel_tag,
             platform_tag = self.platform,
         )
         self.ext_suffix = tags.ext_suffix
         self.abi_tag = tags.abi_tag
+        self.abi_only = tags.abi_only
         self.wheel_tag = tags.wheel_tag
         self.platform = tags.platform_tag
 
@@ -309,6 +313,7 @@ class BuildState:
         properties.setdefault("PyMsbuildTargets", self.targets)
         properties.setdefault("_ProjectBuildTarget", self.target)
         properties.setdefault("SourceRootDir", self.source_dir)
+        properties.setdefault("PythonAbi", self.abi_only)
         properties.setdefault("OutDir", self.build_dir)
         properties.setdefault("IntDir", self.temp_dir)
         properties.setdefault("LayoutDir", self.layout_dir)

--- a/pymsbuild/_tags.py
+++ b/pymsbuild/_tags.py
@@ -75,7 +75,8 @@ def choose_best_tags(
     wheel_tag=None,
     abi_tag=None,
     platform_tag=None,
-    ext_suffix=None
+    ext_suffix=None,
+    abi_only=None
 ):
     if not sys_wheel_tag:
         sys_wheel_tag = next(iter(sys_tags()), None) or "py3-none-any"
@@ -98,11 +99,11 @@ def choose_best_tags(
             wheel_tag = Tag(*wheel_tag.split('-', 3))
 
     # Extract the ABI portion from an explicit ABI tag or wheel tag
-    abi_only = None
-    if abi_tag:
-        abi_only = abi_tag.partition('-')[0]
-    elif wheel_tag and wheel_tag.abi != "*" and "." not in wheel_tag.abi:
-        abi_only = wheel_tag.abi
+    if abi_only in (None, "", "*"):
+        if abi_tag:
+            abi_only = abi_tag.partition('-')[0]
+        elif wheel_tag and wheel_tag.abi != "*" and "." not in wheel_tag.abi:
+            abi_only = wheel_tag.abi
 
     # Overwrite the ABI tag and platform tag from an explicit wheel tag
     if wheel_tag:
@@ -171,4 +172,5 @@ def choose_best_tags(
         abi_tag=abi_tag,
         platform_tag=platform_tag,
         ext_suffix=ext_suffix,
+        abi_only=abi_only,
     )

--- a/pymsbuild/targets/pyd.props
+++ b/pymsbuild/targets/pyd.props
@@ -8,6 +8,7 @@
       <AdditionalIncludeDirectories>$(SourceRootDir.TrimEnd($(_Sep)));$(PythonIncludes);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <Optimization>Full</Optimization>
       <Optimization Condition="$(Configuration) == 'Debug'">Disabled</Optimization>
+      <PreprocessorDefinitions Condition="$(PythonAbi) == 'cp313t' or $(PythonAbi) == 'cp314t'">Py_GIL_DISABLED;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary Condition="$(DynamicLibcppLinkage) == 'true' and $(StaticLibcppLinkage) != 'true'">MultiThreadedDLL</RuntimeLibrary>
       <RuntimeLibrary Condition="$(DynamicLibcppLinkage) != 'true' or $(StaticLibcppLinkage) == 'true'">MultiThreaded</RuntimeLibrary>
     </ClCompile>


### PR DESCRIPTION
Pass Py_GIL_DISABLED to the compiler for ABIs cp313t and cp314t.